### PR TITLE
fix: prevent deletion of existing directories on validation error

### DIFF
--- a/tests/integration/clone.test.ts
+++ b/tests/integration/clone.test.ts
@@ -108,6 +108,7 @@ describe('clone (integration)', () => {
   describe('error cases', () => {
     test('should return error when target path already exists', async () => {
       vi.mocked(fs.pathExists).mockResolvedValue(true);
+      vi.mocked(fs.remove).mockResolvedValue(undefined);
 
       const result = await cloneRepository({
         cloneUrl: 'https://github.com/user/repo.git',
@@ -119,6 +120,8 @@ describe('clone (integration)', () => {
       expect(result.success).toBe(false);
       expect(result.error).toBeInstanceOf(GCPBError);
       expect(result.error?.message).toContain('already exists');
+      // IMPORTANT: Should not remove the existing directory
+      expect(fs.remove).not.toHaveBeenCalled();
     });
 
     test('should return error when clone fails', async () => {


### PR DESCRIPTION
When gcpb add was run with a branch that already existed locally, the validation would correctly fail with "already exists" error, but the error handler was incorrectly deleting the existing directory during cleanup.

Added shouldCleanupOnError flag to only remove directories when clone succeeded but subsequent operations failed, not when pre-clone validation fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)