### PR TITLE
fix: display user inputs in log area during open command

### DIFF
--- a/src/state/open-states.ts
+++ b/src/state/open-states.ts
@@ -4,6 +4,7 @@
  */
 
 import { selectWithEsc } from '../utils/inquirer-helpers.js';
+import chalk from 'chalk';
 import type {
   OpenSelectBranchInput,
   OpenSelectBranchOutput,
@@ -25,6 +26,7 @@ export async function openSelectOrg(
   // If preselected org is provided and valid, skip prompt
   const orgs = [...new Set(repositories.map((r) => r.owner))];
   if (preselectedOrg && orgs.includes(preselectedOrg)) {
+    console.log(chalk.green('✓') + ' Organization: ' + chalk.cyan(preselectedOrg));
     return {
       value: { org: preselectedOrg },
     };
@@ -48,6 +50,8 @@ export async function openSelectOrg(
     })),
   });
 
+  console.log(chalk.green('✓') + ' Organization: ' + chalk.cyan(org));
+
   return {
     value: { org },
   };
@@ -66,6 +70,7 @@ export async function openSelectRepo(
 
   // If preselected repo is provided and valid, skip prompt
   if (preselectedRepo && orgRepos.some((r) => r.repo === preselectedRepo)) {
+    console.log(chalk.green('✓') + ' Repository: ' + chalk.cyan(preselectedRepo));
     return {
       value: { repo: preselectedRepo },
     };
@@ -83,6 +88,8 @@ export async function openSelectRepo(
     })),
   });
 
+  console.log(chalk.green('✓') + ' Repository: ' + chalk.cyan(repo));
+
   return {
     value: { repo },
   };
@@ -98,6 +105,7 @@ export async function openSelectBranch(
 
   // If preselected branch is provided and valid, skip prompt
   if (preselectedBranch && branches.includes(preselectedBranch)) {
+    console.log(chalk.green('✓') + ' Branch: ' + chalk.cyan(preselectedBranch));
     return {
       value: { branch: preselectedBranch },
     };
@@ -111,6 +119,8 @@ export async function openSelectBranch(
     message: 'Select branch to open:',
     choices: branches.map((b) => ({ name: b, value: b })),
   });
+
+  console.log(chalk.green('✓') + ' Branch: ' + chalk.cyan(selectedBranch));
 
   return {
     value: { branch: selectedBranch },


### PR DESCRIPTION
Add console.log statements to open-states.ts to match the add command's logging pattern. This ensures that user selections (organization, repository, branch) are displayed in the log area with green checkmarks, preventing the divider from appearing in the log area.

Fixes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)