### PR TITLE
fix: improve cache update to prune deleted branches and tags

### DIFF
--- a/src/core/cache-manager.ts
+++ b/src/core/cache-manager.ts
@@ -90,8 +90,11 @@ export async function createCache(options: CacheOptions): Promise<void> {
 export async function updateCache(cachePath: string): Promise<void> {
   const git = simpleGit({ baseDir: cachePath });
 
-  // Fetch all refs with prune to remove deleted branches
-  await git.fetch(['--prune', '--tags']);
+  // Fetch all refs from origin with prune to remove deleted branches and tags
+  // --prune: Remove remote-tracking refs that no longer exist on remote
+  // --prune-tags: Remove local tags that no longer exist on remote
+  // For mirror repositories, this ensures the cache stays in sync with the remote
+  await git.fetch(['origin', '--prune', '--prune-tags']);
 }
 
 /**

--- a/tests/unit/core/cache-manager.test.ts
+++ b/tests/unit/core/cache-manager.test.ts
@@ -139,12 +139,12 @@ describe('cache-manager', () => {
   });
 
   describe('updateCache', () => {
-    test('should fetch with prune and tags', async () => {
+    test('should fetch with prune and prune-tags from origin', async () => {
       mockGit.fetch.mockResolvedValue(undefined);
 
       await updateCache('/cache/path');
 
-      expect(mockGit.fetch).toHaveBeenCalledWith(['--prune', '--tags']);
+      expect(mockGit.fetch).toHaveBeenCalledWith(['origin', '--prune', '--prune-tags']);
     });
   });
 


### PR DESCRIPTION
Update the updateCache function to use git fetch with both --prune and --prune-tags options. This ensures that cached mirror repositories stay fully synchronized with the remote by removing deleted branches and tags.

Previously, only --prune and --tags were used, which didn't remove deleted tags from the cache. This caused cached repositories to contain outdated references when cloning from cache.

Changes:
- Add --prune-tags option to git fetch command
- Explicitly specify 'origin' remote for clarity
- Update test expectations to match new behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)